### PR TITLE
:bug: Fix App Clip domain

### DIFF
--- a/AppClip/AppClip.entitlements
+++ b/AppClip/AppClip.entitlements
@@ -4,7 +4,7 @@
 <dict>
 	<key>com.apple.developer.associated-domains</key>
 	<array>
-		<string>search.akkeylab.com</string>
+		<string>appclips:search.akkeylab.com</string>
 	</array>
 	<key>com.apple.developer.parent-application-identifiers</key>
 	<array>

--- a/c-search.entitlements
+++ b/c-search.entitlements
@@ -4,7 +4,7 @@
 <dict>
 	<key>com.apple.developer.associated-domains</key>
 	<array>
-		<string>search.akkeylab.com</string>
+		<string>appclips:search.akkeylab.com</string>
 	</array>
 </dict>
 </plist>


### PR DESCRIPTION
## References
> Second, for each URL that launches your App Clip or full app, add its domain to the Associated Domains capability using this pattern: appclips:\<fully qualified domain\>.

[Associating your App Clip with your website](https://developer.apple.com/documentation/app_clips/associating_your_app_clip_with_your_website)