### PR TITLE
:recycle: Remove unused library in SPM

### DIFF
--- a/Package/Package.swift
+++ b/Package/Package.swift
@@ -14,15 +14,6 @@ let package = Package(
             name: "Presentation",
             targets: ["Presentation"]),
         .library(
-            name: "Domain",
-            targets: ["Domain"]),
-        .library(
-            name: "Data",
-            targets: ["Data"]),
-        .library(
-            name: "Extension",
-            targets: ["Extension"]),
-        .library(
             name: "Clip",
             targets: ["Clip"]),
     ],


### PR DESCRIPTION
The `library` specified in `products` should be limited to those referenced by the application itself