### PR TITLE
:bug: Fix preprocessed info-plist file path

### DIFF
--- a/c-search.xcodeproj/project.pbxproj
+++ b/c-search.xcodeproj/project.pbxproj
@@ -266,7 +266,7 @@
 			inputFileListPaths = (
 			);
 			inputPaths = (
-				"$(SRCROOT)/Preprocessed-Info.plist",
+				"$(TEMP_DIR)/Preprocessed-Info.plist",
 			);
 			name = "Setting Environment Variables";
 			outputFileListPaths = (
@@ -286,7 +286,7 @@
 			inputFileListPaths = (
 			);
 			inputPaths = (
-				"$(SRCROOT)/Preprocessed-Info.plist",
+				"$(TEMP_DIR)/Preprocessed-Info.plist",
 			);
 			name = "Setting Environment Variables";
 			outputFileListPaths = (


### PR DESCRIPTION
## Problem
Environment variable substitution was not working when caching is enabled